### PR TITLE
Name anti-dive and anti-squat directly in the metric list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ tool.
 The calculated metrics include wheel travel, longitudinal wheel-center travel,
 half-track, ISO track, track change, toe angle, ISO steer angle, camber, caster,
 kingpin inclination, scrub radius, mechanical trail, instant-center geometry,
-roll center, heave, suspension roll, ride-height change, anti-pitch geometry,
+roll center, heave, suspension roll, ride-height change, anti-dive and
+anti-squat geometry,
 damper and mechanism travel, and applicable motion ratios. Metric availability
 depends on the architecture and installed mechanisms.
 


### PR DESCRIPTION
The metric list still described these as "anti-pitch geometry", a collective term the rest of the jargon sweep retired in favour of the two named metrics the solver actually reports.

## Contributor terms

- [X] I have read and agree to the contributor terms in
      `CONTRIBUTING.md`. I confirm that I own this contribution or have
      authority to submit it, and I assign the copyright in my contribution
      to Nick McCleery, as maintainer of Suspension Explorer Core, on the
      terms stated there. By checking this box and submitting this pull
      request, I intend this acknowledgement to constitute my electronic
      signature and acceptance of those terms.
