### PR TITLE
chore: release v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-09-07
+
 ### Changed
 
 - Expanded Ruff lint checks and enabled all ty diagnostics as errors, with

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kinematics"
-version = "0.8.0"
+version = "0.8.1"
 description = "Kinematics solver for suspension systems."
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/uv.lock
+++ b/uv.lock
@@ -205,7 +205,7 @@ wheels = [
 
 [[package]]
 name = "kinematics"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
Prepare core v0.8.1: update the package version and lockfile and finalize the changelog.

Merge after CI passes, then use Create core release in the manager to publish the merged commit.
