### PR TITLE
Release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-09-09
+
 ### Added
 
 - Added a versioned capability manifest API and `just manifest` generation flow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kinematics"
-version = "0.8.1"
+version = "0.9.0"
 description = "Kinematics solver for suspension systems."
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/uv.lock
+++ b/uv.lock
@@ -205,7 +205,7 @@ wheels = [
 
 [[package]]
 name = "kinematics"
-version = "0.8.1"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
Prepare core v0.9.0: update release versions and lockfiles and finalize the changelog.

Merge after CI passes, then use Create core release in the manager to publish the merged commit.
